### PR TITLE
xAsh Creek

### DIFF
--- a/AZTurnpoints2021.cup
+++ b/AZTurnpoints2021.cup
@@ -781,6 +781,7 @@ Winslow-Lindbergh Rgnl,335WINSL,US,3501.317N,11043.350W,1506.0m,5,59,2285.7m,,11
 Wisky Ranch/Chevlon,336WISKY,US,3437.000N,11037.683W,1881.2m,2,180,1036.3m,,122.8,Wisky Ranch 6AZ2RY 09/27:3400x80-DIRT|RY 18/36:5000x80-DIRT|MGR: JACK MCCORMICK|480-730-3250,,
 Wood's Airstrip,101Woods,US,3349.013N,11329.015W,598.0m,3,0,0.0m,,,"NLFAA! questionalble -- might be landable with short wings or15m. Report of TS1 prior landing with green wingtips [CH 2012] Woods RY 15/33:1900x50-DIRT|40 FT PLINE 1,000 FT NE OF RY.|MGR: THOMAS A. WOOD|520-859-4141",,
 Wrightson,110WRIGH,US,3142.267N,11050.700W,2564.3m,7,,,,,Wrightson,,
+xAsh Creek,,US,3151.499N,10932.046W,1426.5m,1,,,,,"NO LONGER LANDABLE! Alternative: Sunizona, then Price Ranch. REV 01/19",,
 x Bowie,016BOWI,US,3220.150N,10928.433W,1139.0m,1,,,,,Bowie 122.9 RW width: 70,,
 x Candy Kitchen Ranch,CANDY KI,US,3454.167N,10830.867W,2200.7m,1,,,,,too narrow in 2005 sat image - removed from FAA,,
 x Dunton Ranch,DUTON,US,3512.117N,11321.650W,1559.1m,1,,,,,quite over grown for most of the strip,,


### PR DESCRIPTION
Added xAsh Creek as well as alternative landing site information in the remarks. This was a previously landable field that is now overgrown. REV 05/21