### PR TITLE
911*Gray Ranch

### DIFF
--- a/AZTurnpoints2021.cup
+++ b/AZTurnpoints2021.cup
@@ -321,7 +321,7 @@ Grants-Milan Muni,GRANTSMI,US,3510.033N,10754.117W,1992.5m,5,145,716.3m,,122.8,"
 Grapevine Airstrip  88AZ,Grape8AZ,US,3338.450N,11103.417W,716.3m,5,17,1158.2m,12.2m,122.9,"5mi SE of Roosevelt Lk.   Re-paved and opened 2017, not surveyed.",,
 Grassy Meadows/Sky Ranch Landowners Assn,UT47,US,3706.116N,11318.830W,1021.1m,5,156,1341.1m,,123.05,"Private, UT47, RW width: 50, UNICOM: 123.05",,
 Gray Butte,04CA,US,3433.997N,11740.223W,922.9m,5,80,2438.4m,,,"Private, 04CA, RW width: 150",,
-Gray Ranch,043GRAY,US,3127.517N,10851.750W,1571.2m,5,40,548.6m,,,Gray Ranch NM64RY 04/22:1800x30RY 12/30:1800x50MGR: SETH HADLEY|575-548-2622,,
+911*Gray Ranch,,US,3127.522N,10851.753W,1571.2m,1,,,,,"(NM64)  EMERGENCY ONLY! RWY 04/22: 1800X30, RWY 12/30: 1800X50. Overflown 05/21 12/30 looks overgrown, 04/22 looks good from the air but measures very narrow on Google. Likely abandoned and overgrown. MGR:575-548-2622 REV 05/21",,
 Greene Over Field,GREENE,US,3236.907N,11138.821W,1587ft,3,270,,,,"Surveyed 01/21. Another no brainer. Giant alfalfa field 4000'x1000'. What appears to be N/S roads in the field are smooth dirt even with the surface of the field so rolling across them should be smooth.  Canal on North side, Power lines on North and East sides. Locking gate in the NW corner that will require bolt cutters to defeat. Missed two other possible access points during the survey that should be checked prior to cutting any locks.  Shay Sun is better for access.",,
 H&h Ranch Airstrip,246H HR,US,3445.983N,11232.950W,1531.6m,2,110,670.6m,,,H&H Ranch AZ46RY 11/29:2200x50-DIRT|MGR: CAROL HILLS|928-717-2471,,
 Hacienda Sur Luna,247HACIE,US,3152.667N,10738.733W,1264.9m,5,90,1463.0m,,,Hadienda Sur Luna NM78RY E/W:4800x30-ASPH|MGR: ARLIN H GAMBEL|505-531-2771,,


### PR DESCRIPTION
911*Gray Ranch: Updated Prefix's and remarks. Personal overflight shows 12/30 overgrown, other runway looks enticing and good from the air but when measured on Google has to be way too narrow with side bushes to be safe. REV 05/21